### PR TITLE
Simple and dump solution for avoid lots of reloads

### DIFF
--- a/vue/src/store/modules/companies.js
+++ b/vue/src/store/modules/companies.js
@@ -27,9 +27,9 @@ export default {
   },
   actions: {
     getCompanies({ commit }) {
-      if (this.state.tags.load_wait < Date.now()) {
-        this.state.tags.load_wait = Date.now() + NUMBER_OF_MS_BEFORE_RELOAD;
-        return new Promise((resolve, reject) => {
+      return new Promise((resolve, reject) => {
+        if (this.state.tags.load_wait < Date.now()) {
+          this.state.tags.load_wait = Date.now() + NUMBER_OF_MS_BEFORE_RELOAD;
           Vue.prototype.$axios
             .get("/company")
             .then((resp) => {
@@ -43,8 +43,10 @@ export default {
             .catch((err) => {
               reject(err);
             });
-        });
-      }
+        } else {
+          resolve();
+        }
+      });
     },
     modifyCompany({ commit }, company) {
       return new Promise((resolve, reject) => {

--- a/vue/src/store/modules/companies.js
+++ b/vue/src/store/modules/companies.js
@@ -1,9 +1,11 @@
 import Vue from "vue";
+const NUMBER_OF_MS_BEFORE_RELOAD = 60000; // Don't reload more often then ones an hour.
 
 export default {
   namespaced: true,
   state: () => ({
     companies: [],
+    load_wait: 0,
   }),
   mutations: {
     modifyCompany(state, company) {
@@ -25,21 +27,24 @@ export default {
   },
   actions: {
     getCompanies({ commit }) {
-      return new Promise((resolve, reject) => {
-        Vue.prototype.$axios
-          .get("/company")
-          .then((resp) => {
-            commit("removeAllCompanies");
-            const companies = resp.data;
-            if (companies.length > 0) {
-              commit("setCompanies", companies);
-            }
-            resolve(resp);
-          })
-          .catch((err) => {
-            reject(err);
-          });
-      });
+      if (this.state.tags.load_wait < Date.now()) {
+        this.state.tags.load_wait = Date.now() + NUMBER_OF_MS_BEFORE_RELOAD;
+        return new Promise((resolve, reject) => {
+          Vue.prototype.$axios
+            .get("/company")
+            .then((resp) => {
+              commit("removeAllCompanies");
+              const companies = resp.data;
+              if (companies.length > 0) {
+                commit("setCompanies", companies);
+              }
+              resolve(resp);
+            })
+            .catch((err) => {
+              reject(err);
+            });
+        });
+      }
     },
     modifyCompany({ commit }, company) {
       return new Promise((resolve, reject) => {

--- a/vue/src/store/modules/tags.js
+++ b/vue/src/store/modules/tags.js
@@ -73,9 +73,9 @@ export default {
   },
   actions: {
     getTags({ commit }) {
-      if (this.state.tags.load_wait < Date.now()) {
-        this.state.tags.load_wait = Date.now() + NUMBER_OF_MS_BEFORE_RELOAD;
-        return new Promise((resolve, reject) => {
+      return new Promise((resolve, reject) => {
+        if (this.state.tags.load_wait < Date.now()) {
+          this.state.tags.load_wait = Date.now() + NUMBER_OF_MS_BEFORE_RELOAD;
           Vue.prototype.$axios
             .get("/tag")
             .then((resp) => {
@@ -116,8 +116,10 @@ export default {
             .catch((err) => {
               reject(err);
             });
-        });
-      }
+        } else {
+          resolve();
+        }
+      });
     },
     modifyTag({ commit }, tags) {
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
A simple solution for a avoid of reloads, adds a simple timestamp when next load is will be allowed, if the current load attempt is before the timestamp then we don't make a call to the backend. I set one hour a the minimum time between calls as the data probably wouldn't change very change very often but it also often enough so that the info can be update a few time during the fair.