### PR TITLE
fixes navigation to work and only show when needed

### DIFF
--- a/vue/src/router/index.ts
+++ b/vue/src/router/index.ts
@@ -55,6 +55,7 @@ const router = createRouter({
           component: Company_view,
           meta: {
             noAuth: true,
+            navigation: true,
           },
         },
         {
@@ -95,6 +96,7 @@ const router = createRouter({
           component: Prepage_view,
           meta: {
             noAuth: true,
+            navigation: true,
           },
         }],
     },

--- a/vue/src/stores/modules/site_settings.ts
+++ b/vue/src/stores/modules/site_settings.ts
@@ -1,4 +1,5 @@
 import { defineStore } from "pinia";
+import { unref } from "vue";
 
 const NUMBER_OF_MS_BEFORE_RELOAD = 60000; // Don't reload more often then ones an hour.
 
@@ -14,6 +15,10 @@ interface State {
   settings: {
     company_view: {
       cards: Card[]
+    },
+    navigation: {
+      next: string | undefined;
+      prev: string | undefined;
     }
   },
   load_wait: number,
@@ -25,6 +30,10 @@ export const useSite_settingsStore = defineStore('site_settings', {
     settings: {
       company_view: {
         cards: [],
+      },
+      navigation: {
+        next: undefined,
+        prev: undefined,
       },
     },
     load_wait: 0,
@@ -88,5 +97,16 @@ export const useSite_settingsStore = defineStore('site_settings', {
           });
       });
     },
+    consumeNext() {
+      const temp = unref(this.settings.navigation.next)
+      this.settings.navigation.next = undefined
+      console.log("consumedNext", this.settings.navigation.next)
+      return temp
+    },
+    consumePrev() {
+      const temp = unref(this.settings.navigation.prev)
+      this.settings.navigation.prev = undefined
+      return temp
+    }
   },
 });

--- a/vue/src/views/Landing.vue
+++ b/vue/src/views/Landing.vue
@@ -18,7 +18,7 @@
               color="primary"
               size="lg"
               label="Browse the catalogue"
-              to="/prepage/0"
+              to="/prepage/1"
             ></q-btn>
           </q-card-actions>
         </q-card>

--- a/vue/src/views/userLayout.vue
+++ b/vue/src/views/userLayout.vue
@@ -69,8 +69,9 @@
     <q-drawer :width="200" side="left" persistent show-if-above>
       <div class="navigation">
         <q-btn
+          v-if="hasPrev && $route.meta.navigation"
           elevation="4"
-          v-on:click="$emit('prev')"
+          v-on:click="prev()"
           icon="mdi-arrow-left"
           size="lg"
           round
@@ -87,8 +88,9 @@
     <q-drawer :width="200" side="right" persistent show-if-above>
       <div class="navigation">
         <q-btn
+          v-if="hasNext && $route.meta.navigation"
           elevation="4"
-          v-on:click="$emit('next')"
+          v-on:click="next()"
           icon="mdi-arrow-right"
           size="lg"
           round
@@ -112,18 +114,15 @@
 import axios from "@/plugins/axios";
 import { useAuthStore } from "@/stores/modules/auth";
 import { useLayoutsStore } from "@/stores/modules/layouts";
+import { useSite_settingsStore } from "@/stores/modules/site_settings";
 import { computed, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
-
-const emit = defineEmits<{
-  (e: "next"): void;
-  (e: "prev"): void;
-}>();
 
 const route = useRoute();
 const router = useRouter();
 const authStore = useAuthStore();
 const layoutsStore = useLayoutsStore();
+const site_settingsStore = useSite_settingsStore();
 
 const leftDrawerOpen = ref(false);
 
@@ -136,6 +135,23 @@ const links = [
 
 const leftLayout = computed(() => layoutsStore.getSide("left"));
 const rightLayout = computed(() => layoutsStore.getSide("right"));
+const hasNext = computed(
+  () => site_settingsStore.settings.navigation.next !== undefined
+);
+
+const hasPrev = computed(
+  () => site_settingsStore.settings.navigation.prev !== undefined
+);
+
+function next() {
+  const maybeNext: string | undefined = site_settingsStore.consumeNext();
+  if (maybeNext) router.push(maybeNext);
+}
+
+function prev() {
+  const maybePrev: string | undefined = site_settingsStore.consumePrev();
+  if (maybePrev) router.push(maybePrev);
+}
 
 function logout() {
   useAuthStore().logout();


### PR DESCRIPTION
Fixes the navigation buttons on sides to only show when needed (on company and prepage). Also removes them when there's nothing to show as next or prev on those pages as well.

Makes use of the settings_store in order to pass the data from the layout (which is a parent component) down to steps to either the prepage och company component which then has functions to handle next and prev depending on the values in the store.