### PR TITLE
Enh/search view

### DIFF
--- a/vue/src/components/search/search_card.vue
+++ b/vue/src/components/search/search_card.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-card>
+  <q-card flat>
     <q-card-section>
       <q-input
         filled
@@ -18,6 +18,7 @@
             @click="expanded = !expanded"
           ></q-btn>
           <q-btn
+            class="q-ml-sm"
             label="Search"
             color="primary"
             noCaps

--- a/vue/src/stores/modules/favorites.ts
+++ b/vue/src/stores/modules/favorites.ts
@@ -25,6 +25,13 @@ export const useFavoritesStore = defineStore('favorites', {
         JSON.stringify(Array.from(this.favorites.values()))
       );
     },
+    toggleFavorite(id: number) {
+      if (!this.isFavorite(id)) {
+        this.addFavorite(id)
+      } else {
+        this.removeFavorite(id)
+      }
+    },
     loadFromStorage() {
       const stored_favorites = localStorage.getItem("favorites") || "[]"
       if (stored_favorites == "{}") {

--- a/vue/src/views/search.vue
+++ b/vue/src/views/search.vue
@@ -16,13 +16,13 @@
             (_event, row, _index) => router.push('/company/' + row.name)
           "
         >
-          <template #body-cell-Programs="props">
+          <template #body-cell-Logo="props">
             <q-td :props="props">
-              <TagGroup :tags="props.value"></TagGroup
-            ></q-td>
+              <Image :imageName="props.value"></Image>
+            </q-td>
           </template>
 
-          <template #body-cell-Business_areas="props">
+          <template #body-cell-Programs="props">
             <q-td :props="props">
               <TagGroup :tags="props.value"></TagGroup
             ></q-td>
@@ -47,18 +47,20 @@
           </template>
 
           <template #body-cell-Favorites="props">
-            <q-td :props="props">
+            <q-td :props="props" auto-width>
               <q-icon
                 v-if="props.value"
                 size="sm"
                 name="mdi-star"
                 color="primary"
+                @click.stop="favoritesStore.removeFavorite(props.row.id)"
               ></q-icon>
               <q-icon
                 v-else
                 size="sm"
                 name="mdi-star-outline"
                 color="grey"
+                @click.stop="favoritesStore.addFavorite(props.row.id)"
               ></q-icon>
             </q-td>
           </template>
@@ -79,6 +81,8 @@ import type { Company } from "@/stores/modules/companies";
 import { computed } from "vue";
 import { useTagsStore } from "@/stores/modules/tags";
 import TagGroup from "@/components/Tag_group.vue";
+import Image from "@/components/utils/Image.vue";
+import { useQuasar } from "quasar";
 
 const site_settingsStore = useSite_settingsStore();
 const filterStore = useFilterStore();
@@ -94,44 +98,61 @@ const visibleCards = site_settingsStore.settings.company_view.cards.filter(
 function isVisible(name: string): boolean {
   return visibleCards.some((c) => c.name === name);
 }
-const columns = [
-  { name: "Name", label: "Name", field: "name", align: "left" },
-  {
-    name: "Programs",
-    label: "Programs",
-    field: (row: Company) => tagsStore.getDivisionsFromIds(row.tags),
-    align: "left",
-  },
-  {
-    name: "Business_areas",
-    label: "Business areas",
-    field: (row: Company) => tagsStore.getBusinessAreasFromIds(row.tags),
-    align: "left",
-  },
-  {
-    name: "Looking_for",
-    label: "Looking for",
-    field: (row: Company) => tagsStore.getLookingForFromIds(row.tags),
-    align: "left",
-  },
-  {
-    name: "Offering",
-    label: "Offering",
-    field: (row: Company) => tagsStore.getOfferingsFromIds(row.tags),
-    align: "left",
-  },
-  {
-    name: "Fair_area",
-    label: "Fair Area",
-    field: (row: Company) => tagsStore.getFairAreasFromIds(row.tags),
-    align: "left",
-  },
-  {
-    name: "Favorites",
-    label: "Favorites",
-    field: (row: Company) => favoritesStore.favorites.has(row.id),
-    align: "center",
-  },
-];
+
+const initialPagination = {
+  sortBy: "desc",
+  descending: false,
+  page: 1,
+  rowsPerPage: 10,
+};
+
+const $q = useQuasar();
+const columns = computed(() => {
+  const tempCols = [
+    { name: "Logo", label: "Logo", field: "logo", align: "left", mobile: true },
+    { name: "Name", label: "Name", field: "name", align: "left", mobile: true },
+    {
+      name: "Programs",
+      label: "Programs",
+      field: (row: Company) => tagsStore.getDivisionsFromIds(row.tags),
+      align: "left",
+    },
+    {
+      name: "Looking_for",
+      label: "Looking for",
+      field: (row: Company) => tagsStore.getLookingForFromIds(row.tags),
+      align: "left",
+    },
+    {
+      name: "Offering",
+      label: "Offering",
+      field: (row: Company) => tagsStore.getOfferingsFromIds(row.tags),
+      align: "left",
+    },
+    {
+      name: "Fair_area",
+      label: "Fair Area",
+      field: (row: Company) => tagsStore.getFairAreasFromIds(row.tags),
+      align: "left",
+    },
+    {
+      name: "Favorites",
+      label: "Favorites",
+      field: (row: Company) => favoritesStore.favorites.has(row.id),
+      align: "center",
+      mobile: true,
+    },
+  ];
+  if ($q.screen.lt.md) {
+    return tempCols
+      .filter((col) => col.mobile)
+      .map((col) => {
+        delete col.mobile;
+        return col;
+      });
+  } else {
+    return tempCols;
+  }
+});
 const router = useRouter();
 </script>

--- a/vue/src/views/search.vue
+++ b/vue/src/views/search.vue
@@ -144,12 +144,7 @@ const columns = computed(() => {
     },
   ];
   if ($q.screen.lt.md) {
-    return tempCols
-      .filter((col) => col.mobile)
-      .map((col) => {
-        delete col.mobile;
-        return col;
-      });
+    return tempCols.filter((col) => col.mobile);
   } else {
     return tempCols;
   }


### PR DESCRIPTION
Fixes some layout and bugs in search_view

* adds logo to table
* removes bussiness areas from table
* filters the table to only display logo, name & favorite on mobile
* makes favorite icon clickable to change favorite status in table
* adds some padding to the search button
* makes the search_card flat
* adds an (as of now unused) function to favorites store that let's us toggle the favorite state of an id.